### PR TITLE
Allow counter to increment by float

### DIFF
--- a/src/Prometheus/Counter.php
+++ b/src/Prometheus/Counter.php
@@ -26,7 +26,7 @@ class Counter extends Collector
     }
 
     /**
-     * @param int $count e.g. 2
+     * @param float $count  e.g. 3.14
      * @param array $labels e.g. ['status', 'opcode']
      */
     public function incBy($count, array $labels = array())
@@ -41,7 +41,7 @@ class Counter extends Collector
                 'labelNames' => $this->getLabelNames(),
                 'labelValues' => $labels,
                 'value' => $count,
-                'command' => Adapter::COMMAND_INCREMENT_INTEGER
+                'command' => Adapter::COMMAND_INCREMENT_FLOAT
             )
         );
     }


### PR DESCRIPTION
In prometheus documentation, a counter must have a "inc" method with a double as argument.
https://prometheus.io/docs/instrumenting/writing_clientlibs/#counter

Translated for this library, method Counter::incBy() must accept a float as first argument.